### PR TITLE
Add space after variable used as a key in the extend function for keymap

### DIFF
--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -44,7 +44,7 @@ let s:keymap = get(g:, 'nv_keymap',
 
 " Use `extend` in case user overrides default keys
 let s:keymap = extend(s:keymap, {
-            \ s:create_note_key: s:create_note_window,
+            \ s:create_note_key : s:create_note_window,
             \ })
 
 " FZF expect comma sep str


### PR DESCRIPTION
The plugin was throwing an error that s:create_note_key: was not defined on vim v8.0.0703 on osx. I'm not sure whether this was a change in vimscript behavior, but a space between the key and colon resolves the error. I haven't tested this on other vim versions but I believe this syntax has been valid a while.