### PR TITLE
Update notational_fzf.vim

### DIFF
--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -194,6 +194,7 @@ command! -nargs=* -bang NV
                    \ 'rg',
                    \ '--follow',
                    \ '--hidden',
+                   \ '-i',
                    \ '--line-number',
                    \ '--color never',
                    \ '--no-messages',


### PR DESCRIPTION
It's just one line to make it case insensitive. Given that I search in notes, I want to type `account` and get all matches for `Account` and `account`. 
If it was code, then i would prefer it to not be case insensitive.

#28 