### PR TITLE
Readded --exact

### DIFF
--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -212,7 +212,7 @@ command! -nargs=* -bang NV
                                \ '--print-query',
                                \ '--ansi',
                                \ '--multi',
-                               \ '--exact',
+                               \ '-i',
                                \ '--expect=ctrl-y',
                                \ '--inline-info',
                                \ '--delimiter=":"',

--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -212,6 +212,7 @@ command! -nargs=* -bang NV
                                \ '--print-query',
                                \ '--ansi',
                                \ '--multi',
+                               \ '--exact',
                                \ '-i',
                                \ '--expect=ctrl-y',
                                \ '--inline-info',


### PR DESCRIPTION
Sorry, you were right. Without the `--exact` I start getting lots of gibberish.
However, I noticed that keeping the `-i` option solved the bug where `Account` was not maching with `Online account`.

Bottom line: I'm only adding the `-i` option. It might be redundant with `--exact`, yet, in partice, without it, smart case doesn't seem to be working.