### PR TITLE
Option to respect `*ignore` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ let g:nv_create_note_window = 'vertical split'
 let g:nv_show_preview = 1
 
 " Boolean. Respect .*ignore files in or above nv_search_paths. Set by default.
-let g:nv_ignore_files = 1
+let g:nv_use_ignore_files = 1
 
 " Boolean. Wrap text in preview window.
 let g:nv_wrap_preview_text = 1

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ let g:nv_create_note_window = 'vertical split'
 " Boolean. Show preview. Set by default. Pressing Alt-p in FZF will toggle this for the current search.
 let g:nv_show_preview = 1
 
+" Boolean. Respect .*ignore files in or above nv_search_paths. Set by default.
+let g:nv_ignore_files = 1
+
 " Boolean. Wrap text in preview window.
 let g:nv_wrap_preview_text = 1
 

--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -44,7 +44,7 @@ let s:wrap_text = get(g:, 'nv_wrap_preview_text', 0) ? 'wrap' : ''
 let s:show_preview = get(g:, 'nv_show_preview', 1) ? '' : 'hidden'
 
 " Respect .*ignore files unless user has chosen not to
-let s:ignore_files = get(g:, 'nv_ignore_files', 1) ? '' : '-u'
+let s:use_ignore_files = get(g:, 'nv_use_ignore_files', 1) ? '' : '-u'
 
 " How wide to make preview window. 72 characters is default.
 let s:preview_width = exists('g:nv_preview_width') ? string(float2nr(str2float(g:nv_preview_width) / 100.0 * &columns)) : ''
@@ -199,7 +199,7 @@ command! -nargs=* -bang NV
                    \ 'command',
                    \ 'rg',
                    \ '--follow',
-                   \ s:ignore_files,
+                   \ s:use_ignore_files,
                    \ '--smart-case',
                    \ '--hidden',
                    \ '--line-number',

--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -43,6 +43,9 @@ let s:wrap_text = get(g:, 'nv_wrap_preview_text', 0) ? 'wrap' : ''
 " Show preview unless user set it to be hidden
 let s:show_preview = get(g:, 'nv_show_preview', 1) ? '' : 'hidden'
 
+" Respect .*ignore files unless user has chosen not to
+let s:ignore_files = get(g:, 'nv_ignore_files', 1) ? '' : '-u'
+
 " How wide to make preview window. 72 characters is default.
 let s:preview_width = exists('g:nv_preview_width') ? string(float2nr(str2float(g:nv_preview_width) / 100.0 * &columns)) : ''
 
@@ -196,6 +199,7 @@ command! -nargs=* -bang NV
                    \ 'command',
                    \ 'rg',
                    \ '--follow',
+                   \ s:ignore_files,
                    \ '--smart-case',
                    \ '--hidden',
                    \ '--line-number',


### PR DESCRIPTION
#39 

Adds a boolean option to tell `rg` whether it should respect `.*ignore` files in or above `nv_search_paths`