### PR TITLE
Add option to set filename word separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,12 @@ let g:nv_keymap = {
 " String. Must be in the form 'ctrl-KEY' or 'alt-KEY'
 let g:nv_create_note_key = 'ctrl-x'
 
+" String. Sets the string will be used to separate words in the filename for the created note.
+let g:nv_filename_word_separator = ' '
+
 " String. Controls how new note window is created.
 let g:nv_create_note_window = 'vertical split'
+
 
 " Boolean. Show preview. Set by default. Pressing Alt-p in FZF will toggle this for the current search.
 let g:nv_show_preview = 1

--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -55,6 +55,9 @@ let s:search_paths = map(copy(g:nv_search_paths), 'expand(v:val)')
 " Separator for yanked files
 let s:yank_separator = get(g:, 'nv_yank_separator', "\n")
 
+" Separator for words in filename
+let s:filename_word_seperator = get(g:, 'nv_filename_word_separator', ' ')
+
 " The `exists()` check needs to be first in case the main directory is not
 " part of `g:nv_search_paths`.
 if exists('g:nv_main_directory')
@@ -157,7 +160,8 @@ function! s:handler(lines) abort
 
    " Handle creating note.
    if keypress ==? s:create_note_key
-     let candidates = [fnameescape(s:main_dir  . '/' . query . s:ext)]
+     let filename = join(split(query, ' '), s:filename_word_seperator)
+     let candidates = [fnameescape(s:main_dir  . '/' . filename . s:ext)]
    elseif keypress ==? s:yank_key
      let pat = '\v(.{-}):\d+:'
      let hashes = join(filter(map(copy(a:lines[2:]), 'matchlist(v:val, pat)[1]'), 'len(v:val)'), s:yank_separator)


### PR DESCRIPTION
Hi!

Really nice plugin! Thank you for making it.

I added an option to set a string as word separator to be used when creating new files.
You can set it like so:
    let g:nv_filename_word_separator = "_"
with the result that hitting ctrl-x after
    this is a new search sting
opens the file
   this_is_a_new_search_sting.md