### PR TITLE
Pass window command to fzf#run

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ let g:nv_window_width = '40%'
 " String. Determines where the window is. Valid options are: 'right', 'left', 'up', 'down'.
 let g:nv_window_direction = 'down'
 
+" String. Command to open the window (e.g. `vertical` `aboveleft` `30new` `call my_function()`).
+let g:nv_window_command = 'down'
+let g:nv_window_command = 'call my_function()'
+
 " Float. Width of preview window as a percentage of screen's width. 50% by default.
 let g:nv_preview_width = 50
 

--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -31,6 +31,7 @@ endif
 
 let s:window_direction = get(g:, 'nv_window_direction', 'down')
 let s:window_width = get(g:, 'nv_window_width', '40%')
+let s:window_command = get(g:, 'nv_window_command', '')
 
 let s:ext = get(g:, 'nv_default_extension', '.md')
 
@@ -195,6 +196,7 @@ command! -nargs=* -bang NV
       \ call fzf#run(
           \ fzf#wrap({
               \ 'sink*': function(exists('*NV_note_handler') ? 'NV_note_handler' : '<sid>handler'),
+              \ 'window': s:window_command,
               \ 'source': join([
                    \ 'command',
                    \ 'rg',


### PR DESCRIPTION
Added a new option `g:window_command` – _falls back to an empty string, to preserve current behaviour_ – to pass it to [`fzf#run`](https://github.com/junegunn/fzf/blob/master/README-VIM.md#fzfrun) which will enable the usage of floating windows https://github.com/junegunn/fzf.vim/issues/664#issuecomment-402027457