### PR TITLE
Don't use <C-S> as default or suggested mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Note that the following options can be customized.
 
 -   `c-x`: Use search string as filename and open in vertical split.
 -   `c-v`: Open in vertical split
--   `c-s`: Open in horizontal split
+-   `c-h`: Open in horizontal split
 -   `c-t`: Open in new tab
 -   `c-y`: Yank the selected filenames
 -   `<Enter>`: Open highlighted search result in current buffer
@@ -157,7 +157,7 @@ default. You should use whatever mapping(s) work best for you.
 For example,
 
 ``` {.vim}
-nnoremap <silent> <c-s> :NV<CR>
+nnoremap <silent> <c-n> :NV<CR>
 ```
 
 ## Optional Settings and Their Defaults
@@ -180,7 +180,7 @@ let g:nv_default_extension = '.md'
 " Dictionary with string keys and values. Must be in the form 'ctrl-KEY':
 " 'command' or 'alt-KEY' : 'command'. See examples below.
 let g:nv_keymap = {
-                    \ 'ctrl-s': 'split ',
+                    \ 'ctrl-h': 'split ',
                     \ 'ctrl-v': 'vertical split ',
                     \ 'ctrl-t': 'tabedit ',
                     \ })

--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -88,7 +88,7 @@ let s:yank_key = get(g:, 'nv_yank_key', 'ctrl-y')
 let s:create_note_window = get(g:, 'nv_create_note_window', 'vertical split ')
 
 let s:keymap = get(g:, 'nv_keymap',
-            \ {'ctrl-s': 'split',
+            \ {'ctrl-h': 'split',
             \ 'ctrl-v': 'vertical split',
             \ 'ctrl-t': 'tabedit',
             \ })


### PR DESCRIPTION
Ctrl-S represents the XOFF code in virtually every terminal and causes everything to freeze long before the keypress ever reaches vim or fzf (see <https://unix.stackexchange.com/questions/137842/what-is-the-point-of-ctrl-s> and <https://en.wikipedia.org/wiki/Software_flow_control>). Here I've replaced it with Ctrl-H for horizontal split and Ctrl-N for the suggested keymap in the readme. Let me know if you prefer different keys.