### PR TITLE
Add path normalization so \\users\\xy can be opened

### DIFF
--- a/print_lines.py
+++ b/print_lines.py
@@ -3,6 +3,7 @@
 """Colorize the current line in the preview window in bold red."""
 
 import os
+import os.path as path
 import shutil
 import sys
 
@@ -23,7 +24,7 @@ RESET = "\033[0;0m"
 BOLD = "\033[;1m"
 
 if __name__ == "__main__":
-    with open(file) as f:
+    with open(path.normpath(file)) as f:
         for linenum, line_content in enumerate(f, start=1):
             if beginning <= linenum <= end:
                 if linenum == line:


### PR DESCRIPTION
On windows if the notes are in the %userprofile%/example directory, preview is not available, since python gets \\users\\xy\\example\\xy path which open can't handle, and it will crash silently since called with 2 > NUL