### PR TITLE
Add option for non-space delimited file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ let g:nv_yank_key = 'ctrl-y'
 " String. Separator used between yanked filenames.
 let g:nv_yank_separator = "\n"
 
+" String. Delimiter used between words in a search query when creating a new file.
+let g:nv_yank_separator = " "
+
 " Boolean. If set, will truncate each path element to a single character. If
 " you have colons in your pathname, this will fail. Set by default.
 let g:nv_use_short_pathnames = 1

--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -59,6 +59,9 @@ let s:search_paths = map(copy(g:nv_search_paths), 'expand(v:val)')
 " Separator for yanked files
 let s:yank_separator = get(g:, 'nv_yank_separator', "\n")
 
+" Delimiter for new files created from queries
+let s:file_name_delimiter = get(g:, 'nv_file_name_delimiter', " ")
+
 "=========================== Windows Overrides ============================
 
 if has('win64') || has('win32')
@@ -171,7 +174,8 @@ function! s:handler(lines) abort
 
    " Handle creating note.
    if keypress ==? s:create_note_key
-     let candidates = [fnameescape(s:main_dir  . '/' . query . s:ext)]
+     let delimited_query = substitute(query, ' ', s:file_name_delimiter, 'g')
+     let candidates = [fnameescape(s:main_dir  . '/' . delimited_query . s:ext)]
    elseif keypress ==? s:yank_key
      let pat = '\v(.{-}):\d+:'
      let hashes = join(filter(map(copy(a:lines[2:]), 'matchlist(v:val, pat)[1]'), 'len(v:val)'), s:yank_separator)


### PR DESCRIPTION
Add an option to customize how file names are generated.

I like to avoid spaces in file names to make working on the command line a little easier. This change allows the user to add a custom delimiter between words in their search query e.g. "my search query.md" changes to "my-search-query.md".

