### PR TITLE
add option to date-prefix new files

### DIFF
--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -89,6 +89,12 @@ else
     endif
 endif
 
+if exists('g:nv_date_prefix_fmt')
+  let s:date_prefix = g:nv_date_prefix_fmt
+else
+  let s:date_prefix = ''
+endif
+
 let s:search_path_str = join(map(copy(s:search_paths), 'shellescape(v:val)'))
 
 "=========================== Keymap ========================================
@@ -171,7 +177,7 @@ function! s:handler(lines) abort
 
    " Handle creating note.
    if keypress ==? s:create_note_key
-     let candidates = [fnameescape(s:main_dir  . '/' . query . s:ext)]
+     let candidates = [fnameescape(s:main_dir  . '/' . strftime(s:date_prefix) . query . s:ext)]
    elseif keypress ==? s:yank_key
      let pat = '\v(.{-}):\d+:'
      let hashes = join(filter(map(copy(a:lines[2:]), 'matchlist(v:val, pat)[1]'), 'len(v:val)'), s:yank_separator)


### PR DESCRIPTION
This is definitely a neat plugin -- I'd forgotten how much I liked some of the functionality of ngALT before installing this plugin. fzf + vim is definitely a superior workflow :)

This PR is for a feature I implemented because I found it useful -- when creating a new note, have an (optional) date prefix in the filename. I'm not sure if it's too invasive to include in the core plugin, so feel free to reject this PR if it messes with the underlying notes model too much.

My .vimrc now includes one extra line before including the plugin to enable this feature:

    let g:nv_date_prefix_fmt = '%Y%m%d%I%M-'
