### PR TITLE
nvim: use python3_host_prog

### DIFF
--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -124,7 +124,7 @@ endfunction
 let s:use_short_pathnames = get(g:, 'nv_use_short_pathnames', 1)
 
 " Python 3 is required for this to work
-let s:python_executable = executable('pypy3') ? 'pypy3' : 'python3'
+let s:python_executable = executable('pypy3') ? 'pypy3' : get(g:, 'python3_host_prog', 'python3')
 let s:highlight_path_expr = join([s:python_executable , '-S',expand('<sfile>:p:h:h') . '/print_lines.py' , '{2} {1} ', '2>' . s:null_path,])
 
 if s:use_short_pathnames


### PR DESCRIPTION
and fallback to a python3 in PATH if it exists.

fix https://github.com/alok/notational-fzf-vim/issues/62

if no python is found, it will still fail silently but this pr solves at least one usecase