### PR TITLE
Add --type-add option for rg to filter out unwanted filetypes

### DIFF
--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -34,6 +34,7 @@ let s:window_width = get(g:, 'nv_window_width', '40%')
 let s:window_command = get(g:, 'nv_window_command', '')
 
 let s:ext = get(g:, 'nv_default_extension', '.md')
+let s:file_ext = join(['--type-add="filetype:*', s:ext, '"', ' -tfiletype '], '')
 
 " Valid options are ['up', 'down', 'right', 'left']. Default is 'right'. No colon for
 " this command since it's first in the list.
@@ -223,6 +224,7 @@ command! -nargs=* -bang NV
                    \ s:nv_ignore_pattern,
                    \ '--no-heading',
                    \ '--with-filename',
+                   \ s:file_ext,
                    \ ((<q-args> is '') ?
                      \ '"\S"' :
                      \ shellescape(<q-args>)),


### PR DESCRIPTION
Vimwiki stores content backup in different filetypes, which could lead to redundant results.
Before:
![vimwiki_results_before](https://user-images.githubusercontent.com/15040151/88425628-afca3880-cdbd-11ea-93a9-9d7b63176262.png)

Adding the --type-add option to ripgrep will filter out results from unwanted filetypes. Now it's only showing results from the *.md files, which is the default extension. The filetype is configurable by changing the value of g:nv_default_extension.
After:
![vimwiki_results_after](https://user-images.githubusercontent.com/15040151/88425928-3d0d8d00-cdbe-11ea-9ad1-86c7ed4f48ff.png)



