### PR TITLE
Add user option to sort results by modification time

### DIFF
--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -41,6 +41,9 @@ let s:preview_direction = get(g:, 'nv_preview_direction', 'right')
 
 let s:wrap_text = get(g:, 'nv_wrap_preview_text', 0) ? 'wrap' : ''
 
+" Optionally sort results, which slows down search by making rg nonparallel
+let s:sort_by_modified = get(g:, 'nv_sort_by_modified', 0) ? '--sortr modified' : ''
+
 " Show preview unless user set it to be hidden
 let s:show_preview = get(g:, 'nv_show_preview', 1) ? '' : 'hidden'
 
@@ -213,6 +216,7 @@ command! -nargs=* -bang NV
               \ 'source': join([
                    \ s:command,
                    \ 'rg',
+                   \ s:sort_by_modified,
                    \ '--follow',
                    \ s:use_ignore_files,
                    \ '--smart-case',


### PR DESCRIPTION
`g:nv_sort_by_modified = 1` will tell rg to sort by file modification time. `man rg` says "Note that sorting results currently always forces ripgrep to abandon parallelism and run in a single thread."