### PR TITLE
expand filename to python3

### DIFF
--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -124,7 +124,7 @@ endfunction
 let s:use_short_pathnames = get(g:, 'nv_use_short_pathnames', 1)
 
 " Python 3 is required for this to work
-let s:python_executable = executable('pypy3') ? 'pypy3' : get(g:, 'python3_host_prog', 'python3')
+let s:python_executable = executable('pypy3') ? 'pypy3' : expand(get(g:, 'python3_host_prog', 'python3'), 1)
 let s:highlight_path_expr = join([s:python_executable , '-S',expand('<sfile>:p:h:h') . '/print_lines.py' , '{2} {1} $FZF_PREVIEW_LINES', '2>' . s:null_path,])
 
 if s:use_short_pathnames


### PR DESCRIPTION
On window, with neovim, I got an error running :NV because the full path to python wasn't expanded. This is a simple one-line fix. 