### PR TITLE
Add pre- and post-hooks for integration with other plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ You can also define your own handler function, in case you don't like
 how this plugin handles input but like how it wraps everything else. It
 *must* be called `NV_note_handler`.
 
+Integration with Goyo and other plugins may be accomplished by intercepting
+the `User#NVLeave` event:
+
+``` {.vim}
+autocmd! User NVLeave Goyo
+```
+
+
 ## Potential Use Cases
 
 -   Add `~/notes` and `~/wiki` so your notes are only one key binding

--- a/plugin/notational_fzf.vim
+++ b/plugin/notational_fzf.vim
@@ -169,6 +169,10 @@ function! s:handler(lines) abort
    " Preprocess candidates here. expect lines to have fmt
    " filename:linenum:content
 
+   if exists('#User#NVEnter')
+     doautocmd User NVEnter
+   endif
+
    " Handle creating note.
    if keypress ==? s:create_note_key
      let candidates = [fnameescape(s:main_dir  . '/' . query . s:ext)]
@@ -193,6 +197,9 @@ function! s:handler(lines) abort
        execute join([cmd, candidate])
    endfor
 
+   if exists('#User#NVLeave')
+     doautocmd User NVLeave
+   endif
 endfunction
 
 " If the file you're looking for is empty, then why does it even exist? It's a


### PR DESCRIPTION
This PR adds two events `User#NVEnter` and `User#NVLeave` to enable integration with other plugins such as [junegunn/goyo.vim](https://github.com/junegunn/goyo.vim) and [junegunn/limelight.vim](https://github.com/junegunn/limelight.vim).